### PR TITLE
Add TimeoutContext first pass

### DIFF
--- a/server/routerlicious/packages/services-utils/src/asyncContext.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncContext.ts
@@ -4,15 +4,13 @@
  */
 
 import { AsyncLocalStorage } from "async_hooks";
-import { v4 as uuid } from "uuid";
-import type { RequestHandler, Request, Response } from "express";
-import { CorrelationIdHeaderName } from "@fluidframework/server-services-client";
 import {
-	BaseTelemetryProperties,
 	ITelemetryContextProperties,
-	getGlobalTelemetryContext,
 	ITelemetryContext,
+	Lumberjack,
 } from "@fluidframework/server-services-telemetry";
+import { NetworkError } from "@fluidframework/server-services-client";
+import { ITimeoutContext, ITimeoutContextProperties } from "./timeoutContext";
 
 export class AsyncLocalStorageContextProvider<T> {
 	private readonly asyncLocalStorage = new AsyncLocalStorage<T>();
@@ -42,61 +40,10 @@ export class AsyncLocalStorageContextProvider<T> {
 	}
 }
 
-function getTelemetryContextPropertiesFromRequest(
-	req: Request,
-	res: Response,
-): Partial<ITelemetryContextProperties> {
-	const correlationIdHeader =
-		req.get(CorrelationIdHeaderName) ?? res.get(CorrelationIdHeaderName);
-	// Safely parse and return accepted telemetry properties.
-	return {
-		[BaseTelemetryProperties.correlationId]: correlationIdHeader,
-	};
-}
-
 /**
- * TelemetryContext helper that checks HTTP request and response for {@link TelemetryContextHeaderName} header
- * and returns global telemetry context properties with those request context properties included if they exist.
+ * AsyncLocalStorage based TelemetryContext implementation.
+ * Callbacks are executed within an AsyncContext containing telemetry properties.
  */
-export function getTelemetryContextPropertiesWithHttpInfo(
-	req: Request,
-	res: Response,
-): Partial<ITelemetryContextProperties> {
-	const telemetryContextProperties = getGlobalTelemetryContext().getProperties();
-	const httpProperties = getTelemetryContextPropertiesFromRequest(req, res);
-	const properties: Partial<ITelemetryContextProperties> = {
-		...httpProperties,
-		...telemetryContextProperties,
-	};
-	return properties;
-}
-
-/**
- * Express.js Middleware that binds the global telemetry context to the request for its lifetime.
- *
- * Specific telemetry context properties will be set in the response headers.
- * - {@link CorrelationIdHeaderName}: correlationId
- *
- * Requests from the Fluid client may not include a correlationId, so one is generated when unavailable.
- */
-export const bindTelemetryContext = (): RequestHandler => {
-	return (req, res, next) => {
-		const telemetryContext = getGlobalTelemetryContext();
-		if (!telemetryContext) {
-			return next();
-		}
-		// Bind incoming telemetry properties to async context.
-		const telemetryContextProperties = getTelemetryContextPropertiesWithHttpInfo(req, res);
-		// Generate entry correlation-id if not provided in request.
-		if (!telemetryContextProperties.correlationId) {
-			telemetryContextProperties.correlationId = uuid();
-		}
-		// Assign response headers for client telemetry purposes.
-		res.setHeader(CorrelationIdHeaderName, telemetryContextProperties.correlationId);
-		telemetryContext.bindProperties(telemetryContextProperties, () => next());
-	};
-};
-
 export class AsyncLocalStorageTelemetryContext implements ITelemetryContext {
 	private readonly contextProvider = new AsyncLocalStorageContextProvider<
 		Partial<ITelemetryContextProperties>
@@ -119,5 +66,53 @@ export class AsyncLocalStorageTelemetryContext implements ITelemetryContext {
 				callback().then(resolve).catch(reject);
 			});
 		});
+	}
+}
+
+/**
+ * AsyncLocalStorage based TimeoutContext implementation.
+ * Callbacks are executed within an AsyncContext containing timeout info.
+ */
+export class AsyncLocalStorageTimeoutContext implements ITimeoutContext {
+	private readonly contextProvider =
+		new AsyncLocalStorageContextProvider<ITimeoutContextProperties>();
+
+	public bindTimeout(maxDurationMs: number, callback: () => void): void {
+		const timeoutInfo: ITimeoutContextProperties = {
+			startTime: Date.now(),
+			maxDurationMs,
+		};
+		this.contextProvider.bindContext(timeoutInfo, () => callback());
+	}
+
+	public async bindTimeoutAsync<T>(
+		maxDurationMs: number,
+		callback: () => Promise<T>,
+	): Promise<T> {
+		const timeoutInfo: ITimeoutContextProperties = {
+			startTime: Date.now(),
+			maxDurationMs,
+		};
+		return new Promise<T>((resolve, reject) => {
+			this.contextProvider.bindContext(timeoutInfo, () => {
+				callback().then(resolve).catch(reject);
+			});
+		});
+	}
+
+	public checkTimeout(): void {
+		const timeoutInfo = this.contextProvider.getContext();
+		if (!timeoutInfo) {
+			return;
+		}
+		if (timeoutInfo.startTime + timeoutInfo.maxDurationMs < Date.now()) {
+			const error = new NetworkError(503, "Timeout");
+			Lumberjack.error(
+				"[TimeoutContext]: Timeout max duration exceeded.",
+				{ startTime: timeoutInfo.startTime, maxDurationMs: timeoutInfo.maxDurationMs },
+				error,
+			);
+			throw error;
+		}
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -8,7 +8,7 @@ import { v4 as uuid } from "uuid";
 import type { Request, Response, NextFunction } from "express";
 import { CorrelationIdHeaderName } from "@fluidframework/server-services-client";
 import { getGlobalTelemetryContext } from "@fluidframework/server-services-telemetry";
-import { getTelemetryContextPropertiesWithHttpInfo } from "./asyncContext";
+import { getTelemetryContextPropertiesWithHttpInfo } from "./telemetryContext";
 
 /**
  * DEPRECATED

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -9,7 +9,16 @@ export {
 	getCorrelationId,
 	getCorrelationIdWithHttpFallback,
 } from "./asyncLocalStorage";
-export { bindTelemetryContext, getTelemetryContextPropertiesWithHttpInfo } from "./asyncContext";
+export {
+	bindTelemetryContext,
+	getTelemetryContextPropertiesWithHttpInfo,
+} from "./telemetryContext";
+export {
+	ITimeoutContext,
+	bindTimeoutContext,
+	getGlobalTimeoutContext,
+	setGlobalTimeoutContext,
+} from "./timeoutContext";
 export {
 	generateToken,
 	generateUser,

--- a/server/routerlicious/packages/services-utils/src/telemetryContext.ts
+++ b/server/routerlicious/packages/services-utils/src/telemetryContext.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { v4 as uuid } from "uuid";
+import type { RequestHandler, Request, Response } from "express";
+import { CorrelationIdHeaderName } from "@fluidframework/server-services-client";
+import {
+	BaseTelemetryProperties,
+	ITelemetryContextProperties,
+	getGlobalTelemetryContext,
+} from "@fluidframework/server-services-telemetry";
+
+/**
+ * Retrieve telemetry properties from an HTTP request.
+ * For example, gets CorrelationId from x-correlation-id header.
+ */
+function getTelemetryContextPropertiesFromRequest(
+	req: Request,
+	res: Response,
+): Partial<ITelemetryContextProperties> {
+	const correlationIdHeader =
+		req.get(CorrelationIdHeaderName) ?? res.get(CorrelationIdHeaderName);
+	// Safely parse and return accepted telemetry properties.
+	return {
+		[BaseTelemetryProperties.correlationId]: correlationIdHeader,
+	};
+}
+
+/**
+ * TelemetryContext helper that checks HTTP request and response for {@link TelemetryContextHeaderName} header
+ * and returns global telemetry context properties with those request context properties included if they exist.
+ */
+export function getTelemetryContextPropertiesWithHttpInfo(
+	req: Request,
+	res: Response,
+): Partial<ITelemetryContextProperties> {
+	const telemetryContextProperties = getGlobalTelemetryContext().getProperties();
+	const httpProperties = getTelemetryContextPropertiesFromRequest(req, res);
+	const properties: Partial<ITelemetryContextProperties> = {
+		...httpProperties,
+		...telemetryContextProperties,
+	};
+	return properties;
+}
+
+/**
+ * Express.js Middleware that binds the global telemetry context to the request for its lifetime.
+ *
+ * Specific telemetry context properties will be set in the response headers.
+ * - {@link CorrelationIdHeaderName}: correlationId
+ *
+ * Requests from the Fluid client may not include a correlationId, so one is generated when unavailable.
+ */
+export const bindTelemetryContext = (): RequestHandler => {
+	return (req, res, next) => {
+		const telemetryContext = getGlobalTelemetryContext();
+		// Bind incoming telemetry properties to async context.
+		const telemetryContextProperties = getTelemetryContextPropertiesWithHttpInfo(req, res);
+		// Generate entry correlation-id if not provided in request.
+		if (!telemetryContextProperties.correlationId) {
+			telemetryContextProperties.correlationId = uuid();
+		}
+		// Assign response headers for client telemetry purposes.
+		res.setHeader(CorrelationIdHeaderName, telemetryContextProperties.correlationId);
+		telemetryContext.bindProperties(telemetryContextProperties, () => next());
+	};
+};

--- a/server/routerlicious/packages/services-utils/src/timeoutContext.ts
+++ b/server/routerlicious/packages/services-utils/src/timeoutContext.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { RequestHandler } from "express";
+
+export interface ITimeoutContextProperties {
+	/**
+	 * When the action started in milliseconds since epoch.
+	 */
+	startTime: number;
+	/**
+	 * How long the given action is allowed to take before timing out, in milliseconds.
+	 */
+	maxDurationMs: number;
+}
+
+export interface ITimeoutContext {
+	/**
+	 * Attaches timeout info to the callback context.
+	 */
+	bindTimeout(maxDurationMs: number, callback: () => void): void;
+	/**
+	 * Attaches timeout info to the callback context.
+	 * Returns callback result as a promise.
+	 */
+	bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T>;
+	/**
+	 * Checks if the timeout has been exceeded.
+	 * If exceeded, throws a 503 Timeout error
+	 */
+	checkTimeout(): void;
+}
+
+/**
+ * Empty ITimeoutContext that binds nothing never throws.
+ * Callbacks are still executed and returned.
+ */
+class NullTimeoutContext implements ITimeoutContext {
+	bindTimeout(maxDurationMs: number, callback: () => void): void {
+		callback();
+	}
+	async bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T> {
+		return callback();
+	}
+	checkTimeout(): void {}
+}
+const nullTimeoutContext = new NullTimeoutContext();
+
+export const getGlobalTimeoutContext = () =>
+	(global.timeoutContext as ITimeoutContext | undefined) ?? nullTimeoutContext;
+
+export const setGlobalTimeoutContext = (timeoutContext: ITimeoutContext) => {
+	global.telemetryContext = timeoutContext;
+};
+
+/**
+ * Express.js Middleware that binds TimeoutContext to the request for its lifetime.
+ * Within the request flow, `getGlobalTimeoutContext().checkTimeout()` can then be called
+ * strategically to terminate request processing early in case of timeout.
+ */
+export const bindTimeoutContext = (maxRequestDurationMs: number): RequestHandler => {
+	return (req, res, next) => {
+		const timeoutContext = getGlobalTimeoutContext();
+		timeoutContext.bindTimeout(maxRequestDurationMs, () => next());
+	};
+};


### PR DESCRIPTION
## Description

In FRS, sometimes parts of a request will take a really long time to process. By the time that part completes processing, the request has already timedout and thrown an error to the API consumer. We need to be able to jump out of processing a request after it has timed out to prevent expensive further operations.